### PR TITLE
fix destination path

### DIFF
--- a/pkg/commands/split.go
+++ b/pkg/commands/split.go
@@ -23,7 +23,7 @@ func SplitWithPrompt(path string) error {
 		return err
 	}
 
-	return Split(path, path, total, threshold)
+	return Split(path, filepath.Dir(path), total, threshold)
 }
 
 func Split(path string, destination string, total int, threshold int) error {


### PR DESCRIPTION
Without this patch, I get:

```
>> ./horcrux -n 5 -t 5 split LICENSE
2020/07/06 21:03:46 Destination must be a directory
```