### PR TITLE
Add scoop install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ via homebrew:
 brew install jesseduffield/horcrux/horcrux
 ```
 
+via [scoop](https://scoop.sh/):
+```
+scoop bucket add extras; scoop install horcrux
+```
+
 via [binary release](https://github.com/jesseduffield/horcrux/releases)
 
 ## Who this is for:


### PR DESCRIPTION
horcrux was recently added to the scoop 'extras' bucket so now windows users can take advantage of that.